### PR TITLE
Set Display Name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@openhomekit/homebridge-nhc2",
+        "displayName": "Niko Home Control 2",
 	"version": "3.3.0",
 	"description": "Niko Home Control 2 support for Homebridge",
 	"license": "MIT",


### PR DESCRIPTION
The display name is not currently configured. This PR adds `displayName` to package.json to make the name shown in the HomeBridge UI prettier and easier to find in the HomeBridge plugin search. 

![Screenshot 2023-12-18 at 18 16 39](https://github.com/openhomekit/homebridge-nhc2/assets/591634/94945c8a-cfcb-47f3-8a0e-353675ee9fd6)
